### PR TITLE
Update now.json

### DIFF
--- a/now.json
+++ b/now.json
@@ -11,7 +11,7 @@
     },
     {
       "src": "^/blog/$",
-      "dest": "/www/blog/index.js"
+      "dest": "/www/blog/index"
     },
     {
       "src": "^/blog/(.+)$",


### PR DESCRIPTION
The `@now/next` builder outputs files without `.js` extension. Eg:

`pages/abc.js` becomes `/abc`. In case there is a subdirectory like yours (www/package.json) where the path is `www/pages/abc.js` becomes `www/abc`.