### PR TITLE
Add thru-hiking gear recommendations post

### DIFF
--- a/posts/thru-hiking-gear.mdx
+++ b/posts/thru-hiking-gear.mdx
@@ -1,0 +1,42 @@
+---
+title: "My thru-hiking gear recommendations"
+slug: "thru-hiking-gear"
+date: "May 21, 2026"
+---
+# My thru-hiking gear recommendations
+
+A friend asked me what gear I'd recommend for a thru-hike, so I wrote it
+up. These are the four items that matter most — what I used, what I'd
+buy if I were starting over, and the small things I wish someone had
+told me up front.
+
+## Backpack — Hyperlite Southwest 70L
+
+Buy: [Hyperlite Mountain Gear — Southwest 70L](https://hyperlitemountaingear.com/products/southwest)
+
+I used a [Zpacks Arc Haul Ultra 70L](https://zpacks.com/products/arc-haul-ultra-70l-backpack)
+and it was fine, but if I were buying again I'd go with the Hyperlite
+Southwest 70L instead.
+
+## Tent — Zpacks Duplex
+
+Buy: [Zpacks Duplex](https://zpacks.com/products/duplex-tent)
+
+I loved the Duplex and would buy it again without thinking. A few notes:
+
+- **Get the [Freestanding Flex Kit](https://zpacks.com/products/duplex-freestanding-flex-kit).**
+  It's expensive, but worth it.
+- **Get the [Zpacks Tyvek groundsheet](https://zpacks.com/products/tyvek-groundsheet).**
+  It keeps the tent clean and dry and dramatically extends its life.
+  _Important:_ cut it so the entire sheet fits **under** the tent
+  footprint. If any Tyvek sticks out past the edges, rain pools on it
+  and runs underneath you.
+- **Buy a few rolls of [repair tape](https://zpacks.com/collections/repair-tape-patches)
+  with your initial order.** You'll want it eventually, and you'll save
+  the shipping cost.
+
+## Water filter — Platypus QuickDraw
+
+Buy: [Platypus QuickDraw](https://www.platy.com/filtration/quickdraw-filter/quickdraw-filter.html)
+
+I tried both and liked the Platypus much more than the Sawyer.

--- a/posts/thru-hiking-gear.mdx
+++ b/posts/thru-hiking-gear.mdx
@@ -31,7 +31,7 @@ I loved the Duplex and would buy it again without thinking. A few notes:
   _Important:_ cut it so the entire sheet fits **under** the tent
   footprint. If any Tyvek sticks out past the edges, rain pools on it
   and runs underneath you.
-- **Buy a few rolls of [repair tape](https://zpacks.com/collections/repair-tape-patches)
+- **Buy a few rolls of [repair tape](https://zpacks.com/products/54-tape-strip)
   with your initial order.** You'll want it eventually, and you'll save
   the shipping cost.
 


### PR DESCRIPTION
## Summary
- Adds `posts/thru-hiking-gear.mdx`, a short gear-recommendations post (backpack, tent + accessories, water filter) with direct product links
- Renders at `/blog/thru-hiking-gear` via the existing `pages/blog/[slug].js` route
- Follows the `posts/desk-setup.mdx` pattern

## Test plan
- [ ] `npm run dev` and confirm the post renders at http://localhost:3000/blog/thru-hiking-gear
- [ ] Click each product link to verify it lands on the correct page
- [ ] Confirm the post does not appear unwanted anywhere else (nav, home page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)