### PR TITLE
chore: update dependency lockfile to latest patch/minor versions

### DIFF
--- a/docs/plans/2026-07-19-001-chore-dependency-cleanup-plan.md
+++ b/docs/plans/2026-07-19-001-chore-dependency-cleanup-plan.md
@@ -1,0 +1,164 @@
+---
+title: Dependency PR Cleanup and Consolidated Update
+type: chore
+status: active
+date: 2026-07-19
+---
+
+# Dependency PR Cleanup and Consolidated Update
+
+## Overview
+
+The repo has 30 open Dependabot PRs (#38–#80), all opened between 2020 and March 2023, targeting Gatsby-era dependencies (gatsby, gatsby-plugin-mdx, express, moment, socket.io, ajv, etc.). The site was fully migrated from Gatsby to Next.js in PR #86 (`7126a92 Migrate from Gatsby to Next.js`), and there is no `.github/dependabot.yml` in the repo today, so no new dependency PRs have been generated since. None of these 30 PRs are mergeable or relevant anymore — the packages they touch either don't exist in `package.json`/`package-lock.json` at all, or (in the one case of `styled-jsx`) their diff is against the old npm lockfile v1 format, incompatible with the current lockfile v3 structure.
+
+This plan closes all 30 stale PRs and replaces them with a single PR that brings currently-used dependencies up to date. PR #81 (`chore: expand .gitignore for local artifacts`) was a separate, unrelated chore PR from a bot account; it is already closed and requires no action here — noted only so it isn't mistaken for part of this cleanup.
+
+## Problem Frame
+
+Open PR clutter obscures real work and each stale PR still consumes CI/notification overhead. The user wants the noise cleared and a single, current, low-risk dependency bump landed instead of trying to resurrect any of the old bumps.
+
+## Requirements Trace
+
+- R1. Every one of the 30 Dependabot PRs (#38–#80) is confirmed obsolete before closing (not just assumed).
+- R2. All 30 are closed with a brief explanatory comment.
+- R3. A single new PR lands that updates real, currently-used dependencies to their latest safe versions.
+- R4. Major-version upgrades (Tailwind v3→v4, Prettier v2→v3) are explicitly excluded from this PR — confirmed with user, too risky to bundle silently.
+- R5. PR #81 is not touched by this cleanup (already closed independently; no action needed).
+
+## Scope Boundaries
+
+- No Tailwind v4 or Prettier v3 migration work (config rewrite, formatting-output review) — future work if desired.
+- No action on PR #81 — already closed, unrelated to dependency management.
+- No new `.github/dependabot.yml` — re-enabling automated dependency PRs is a separate decision, not part of this cleanup.
+- Does not address the pre-existing transitive `js-yaml <3.15.0` advisory (comes from `gray-matter@4.0.3`, no newer `gray-matter` release fixes it), nor the nested `postcss` advisory inside `next`'s own bundled copy — confirmed this bump does not clear it (see Context & Research) — both are noted but not blocking, see Risks.
+
+## Context & Research
+
+### Verified current state (as of 2026-07-19)
+
+- `package.json` dependencies are entirely Next.js/React based (`next ^16.2.0`, `react ^19.2.0`, `react-dom ^19.2.0`, `next-mdx-remote-client ^2.1.10`, `@mdx-js/mdx ^3.1.1`, `gray-matter ^4.0.3`, `prismjs ^1.30.0`, `prism-react-renderer ^2.4.1`, `styled-jsx ^5.1.7`, `prop-types ^15.7.2`) plus devDependencies (`@next/swc-wasm-nodejs`, `autoprefixer`, `postcss`, `prettier 2.0.5`, `tailwindcss ^3.4.17`).
+- `grep -ril gatsby` across the repo (excluding `node_modules`) returns nothing — zero remaining references.
+- `npm outdated` output:
+
+  | Package | Current | Wanted | Latest |
+  |---|---|---|---|
+  | @next/swc-wasm-nodejs | 16.2.6 | 16.2.10 | 16.2.10 |
+  | autoprefixer | 10.5.0 | 10.5.4 | 10.5.4 |
+  | next | 16.2.6 | 16.2.10 | 16.2.10 |
+  | next-mdx-remote-client | 2.1.10 | 2.1.11 | 2.1.11 |
+  | postcss | 8.5.14 | 8.5.20 | 8.5.20 |
+  | prettier | 2.0.5 | 2.0.5 | 3.9.5 |
+  | react | 19.2.6 | 19.2.7 | 19.2.7 |
+  | react-dom | 19.2.6 | 19.2.7 | 19.2.7 |
+  | tailwindcss | 3.4.19 | 3.4.19 | 4.3.3 |
+
+- **Key decision-relevant fact:** every "Wanted" version above (except prettier/tailwindcss, which don't move under `npm update`) already falls inside the caret range already declared in `package.json`. E.g. `"next": "^16.2.0"` permits `16.2.10`; `"react": "^19.2.0"` permits `19.2.7`. This means the consolidated update needs **no `package.json` edits** — only `npm update` (or equivalent) regenerating `package-lock.json`, which npm will do for packages whose current range already allows the newer version.
+- `npm audit` reports 3 moderate advisories: `js-yaml <3.15.0` (transitive via `gray-matter@4.0.3`, no newer `gray-matter` release available to fix it) and `postcss` inside `next`'s own internally-bundled copy (`node_modules/next/node_modules/postcss@8.4.31`, separate from the top-level postcss). Neither is fixed by `npm audit fix` without `--force` (which would downgrade `next` to `9.3.3` — not applicable/wanted). **Confirmed:** `npm view next@16.2.10 dependencies.postcss` returns `8.4.31` — identical to the version bundled by the current `next@16.2.6`. Bumping `next` to `16.2.10` does **not** clear the nested postcss advisory; it will still show 3 moderate advisories after this update.
+
+### Evidence that the 30 PRs are obsolete
+
+- `gh pr diff 71` (bumping `loader-utils`/`styled-jsx`) shows a diff against `package-lock.json` in the old nested lockfile v1 format (`"requires": {...}"` blocks) — structurally incompatible with the current lockfile v3 file. None of these PRs can be cleanly merged or rebased.
+- Package names across all 30 PRs (gatsby, gatsby-plugin-mdx, gatsby-transformer-remark, gatsby-plugin-sharp, express, moment, socket.io, socket.io-parser, engine.io, terser, devcert, url-parse, ajv, color-string, object-path, tar, path-parse, dns-packet, browserslist, hosted-git-info, lodash, ssri, y18n, elliptic, ini, json5, flat, minimist, http-cache-semantics, qs, decode-uri-component, loader-utils) — none appear in current `package.json`. `prismjs` is the only name that overlaps with a current dependency, and PR #63's target (1.27.0) is already below the current installed version (1.30.0).
+- No `.github/dependabot.yml` exists in the repo, confirming Dependabot is not actively generating new PRs — these are 100% legacy leftovers from the Gatsby era.
+
+## Key Technical Decisions
+
+- **Close, don't attempt to rebase, any of the 30 PRs.** Rationale: their base lockfile format predates the Gatsby→Next.js migration; rebasing is not meaningfully different from a fresh update, and the target packages no longer exist in the tree.
+- **Bundle only patch/minor updates into the single new PR; exclude Tailwind v4 and Prettier v3.** Rationale (user-confirmed): both are major, breaking upgrades — Tailwind v4 changes the config format entirely (CSS-first config) and Prettier v3 changes formatting output across the codebase. Bundling either would turn a "safe cleanup" PR into a migration project and obscure the real dependency bump in a large reformatting diff.
+- **No `package.json` version-range edits needed.** Rationale: verified every in-scope package's newer version already satisfies its existing caret range; only the lockfile changes.
+- **No action on PR #81.** Rationale: unrelated to dependency management (gitignore + package.json edit from a different bot); it's already closed independently of this plan.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the consolidated PR include Tailwind v4 / Prettier v3? → No, patch/minor only (user-confirmed).
+- Should PR #81 be closed as part of this cleanup? → Not applicable — it's already closed; confirmed out of scope regardless (user-confirmed).
+- Does bumping `next` to `16.2.10` clear the nested `postcss` advisory? → No — confirmed via `npm view next@16.2.10 dependencies.postcss` (returns `8.4.31`, same as current); the advisory persists after this PR.
+
+### Deferred to Implementation
+
+None — all planning-time questions were resolved above.
+
+## Implementation Units
+
+- [x] **Unit 1: Close the 30 obsolete Dependabot PRs**
+
+**Goal:** Clear out PRs #38–#80 (all Dependabot dependency bumps) with a brief explanatory comment so the closure reason is visible in PR history, without touching #81 (already closed, unrelated).
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** None
+
+**Files:** None (PR/issue-tracker operation only, no repo file changes)
+
+**Approach:**
+- For each of these 30 PR numbers — 38, 41, 42, 43, 45, 46, 47, 48, 52, 53, 56, 58, 61, 63, 64, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80 — post a short comment (e.g. "Closing — superseded by the Gatsby→Next.js migration (#86); this dependency no longer exists in the project.") and close the PR. This list is exhaustive; do not close any PR outside it, and #81 is not in this list.
+- Do not delete the associated `dependabot/npm_and_yarn/*` branches as part of this unit — Dependabot/GitHub typically auto-deletes or they can be cleaned up separately; not required for the PR closure itself.
+
+**Test expectation:** none -- administrative PR-closing action, no code behavior involved.
+
+**Verification:**
+- `gh pr list --state open` no longer shows PRs #38–#80.
+- Each closed PR has a closing comment explaining why.
+
+- [x] **Unit 2: Update package-lock.json to latest versions within existing ranges**
+
+**Goal:** Bring `next`, `@next/swc-wasm-nodejs`, `autoprefixer`, `next-mdx-remote-client`, `postcss`, `react`, and `react-dom` up to their latest patch/minor versions, all already permitted by current `package.json` caret ranges.
+
+**Requirements:** R4 (prerequisite work toward R3, which Unit 3 completes by landing the PR)
+
+**Dependencies:** None (independent of Unit 1)
+
+**Files:**
+- Modify: `package-lock.json` (regenerated by npm; no expected `package.json` diff since ranges already permit the target versions)
+
+**Approach:**
+- Run the package manager's update command scoped to these 7 packages so `tailwindcss` and `prettier` are left untouched (they won't move anyway since `npm update` respects existing ranges, but scoping avoids ambiguity from any tool auto-suggesting a range bump).
+- Confirm `package.json` has no unexpected diff — if npm proposes widening any range, revert that hunk and keep only the lockfile change.
+
+**Patterns to follow:**
+- None needed — this is a standard lockfile refresh, not new code.
+
+**Test expectation:** none -- dependency version bump with no application code change; covered by the build/lint verification below instead of unit tests.
+
+**Verification:**
+- `npm outdated` no longer lists `next`, `@next/swc-wasm-nodejs`, `autoprefixer`, `next-mdx-remote-client`, `postcss`, `react`, or `react-dom` (still lists `prettier` and `tailwindcss`, unchanged, as expected).
+- `npm run build` completes successfully.
+- `npm audit` shows the same or fewer advisories than before (3 moderate, all pre-existing and unrelated to this bump) — no new advisories introduced.
+- `git diff package.json` is empty or contains no unintended range widening.
+
+- [ ] **Unit 3: Open the consolidated dependency-update PR**
+
+**Goal:** Land Unit 2's lockfile changes as a single, clearly-described PR.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 2
+
+**Files:** None beyond what Unit 2 already changed.
+
+**Approach:**
+- Branch from `main`, commit the `package-lock.json` update.
+- PR description should list the 7 packages and old→new versions (from the table in Context & Research), note that Tailwind v4 and Prettier v3 were deliberately excluded as follow-up work, and reference that this replaces the 30 closed Dependabot PRs.
+
+**Test expectation:** none -- process/PR-creation step, no additional code change beyond Unit 2.
+
+**Verification:**
+- PR is open, the `linter.yml` CI workflow (`.github/workflows/linter.yml`) passes, description accurately reflects the version table above.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Closing PRs without comment looks like silent dismissal to anyone auditing PR history later | Unit 1 requires a brief comment on each closed PR explaining the Gatsby→Next.js migration made them obsolete |
+| `next` patch bump (16.2.6→16.2.10) could carry subtle behavior changes despite being a patch version | `npm run build` verification in Unit 2 catches build-breaking issues; this is a personal blog with low traffic risk, so a quick manual smoke check of the built site is reasonable but not mandated by this plan |
+| Pre-existing `js-yaml`/nested-`postcss` moderate advisories remain after this PR (confirmed: `next@16.2.10` still bundles `postcss@8.4.31`) | Explicitly out of scope (see Scope Boundaries); flagged here so it isn't mistaken for something this PR was supposed to fix |
+| Excluding Tailwind v4/Prettier v3 means those upgrades still need to happen eventually | Deliberate scope decision (user-confirmed); worth a future plan once there's bandwidth for the config migration |
+
+## Sources & References
+
+- Migration commit: `7126a92 Migrate from Gatsby to Next.js` (merged via PR #86)
+- Open PRs audited: `gh pr list --state open` (#38–#80, 30 total, captured 2026-07-19; #81 confirmed already closed)
+- Example proof of obsolescence: `gh pr diff 71` (lockfile v1 format, incompatible with current lockfile v3)
+- Current dependency state: `package.json`, `package-lock.json`, `npm outdated`, `npm audit` (all run 2026-07-19)

--- a/docs/plans/2026-07-19-001-chore-dependency-cleanup-plan.md
+++ b/docs/plans/2026-07-19-001-chore-dependency-cleanup-plan.md
@@ -1,7 +1,7 @@
 ---
 title: Dependency PR Cleanup and Consolidated Update
 type: chore
-status: active
+status: completed
 date: 2026-07-19
 ---
 
@@ -128,7 +128,7 @@ None — all planning-time questions were resolved above.
 - `npm audit` shows the same or fewer advisories than before (3 moderate, all pre-existing and unrelated to this bump) — no new advisories introduced.
 - `git diff package.json` is empty or contains no unintended range widening.
 
-- [ ] **Unit 3: Open the consolidated dependency-update PR**
+- [x] **Unit 3: Open the consolidated dependency-update PR**
 
 **Goal:** Land Unit 2's lockfile changes as a single, clearly-described PR.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,12 +42,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -634,15 +634,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
-      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -656,9 +656,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -672,9 +672,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
       ],
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
       ],
@@ -704,9 +704,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
       ],
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
       ],
@@ -736,15 +736,15 @@
       }
     },
     "node_modules/@next/swc-wasm-nodejs": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-wasm-nodejs/-/swc-wasm-nodejs-16.2.6.tgz",
-      "integrity": "sha512-hwa9pdxfzDsug/m4eukZiy2bOXasDAlZG41YCNHqJfXaVQ0c544ox6MvAbvJn7GaVHDrkD+pwVeJz2djKjcsUA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-wasm-nodejs/-/swc-wasm-nodejs-16.2.10.tgz",
+      "integrity": "sha512-64yRgjnZ/PevEimxlf9Z/k9V5OaVlDyYB995bnBDTXYeuH6uE6vFI08ucGI/dWRpLM9ef6j7hYQAj2bW2xM1ng==",
       "dev": true
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -758,9 +758,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
-      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -970,9 +970,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "dev": true,
       "funding": [
         {
@@ -990,8 +990,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1055,9 +1055,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -1075,10 +1075,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -1099,9 +1099,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1348,9 +1348,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.353",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
-      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2763,9 +2763,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -2781,12 +2781,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
-      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.6",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -2800,14 +2800,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.6",
-        "@next/swc-darwin-x64": "16.2.6",
-        "@next/swc-linux-arm64-gnu": "16.2.6",
-        "@next/swc-linux-arm64-musl": "16.2.6",
-        "@next/swc-linux-x64-gnu": "16.2.6",
-        "@next/swc-linux-x64-musl": "16.2.6",
-        "@next/swc-win32-arm64-msvc": "16.2.6",
-        "@next/swc-win32-x64-msvc": "16.2.6",
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -2834,15 +2834,16 @@
       }
     },
     "node_modules/next-mdx-remote-client": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/next-mdx-remote-client/-/next-mdx-remote-client-2.1.10.tgz",
-      "integrity": "sha512-wpLjRYyvOJRewb/PLwID0qbi7RGDiwg6QpTKcM36OnjJ2WIU9nOg0xRs3Q7WgfPteDlFx+zZkJHJ6WrvmIulEg==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/next-mdx-remote-client/-/next-mdx-remote-client-2.1.11.tgz",
+      "integrity": "sha512-R28K170ODHCdzoqyoNosTSMGKEj/MEHknQELSjK6eQVsGXxeQ3brORmusql3AvPBqTGOfYVVeTvuIC/133UZxw==",
       "license": "MPL 2.0",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
         "@mdx-js/mdx": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
-        "remark-mdx-remove-esm": "^1.3.1",
+        "@types/mdx": "^2.0.13",
+        "remark-mdx-remove-esm": "^1.3.2",
         "serialize-error": "^13.0.1",
         "vfile": "^6.0.3",
         "vfile-matter": "^5.0.1"
@@ -2907,11 +2908,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/non-error": {
       "version": "0.1.0",
@@ -3026,9 +3030,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -3046,7 +3050,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3266,24 +3270,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -3412,13 +3416,12 @@
       }
     },
     "node_modules/remark-mdx-remove-esm": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/remark-mdx-remove-esm/-/remark-mdx-remove-esm-1.3.1.tgz",
-      "integrity": "sha512-POa8abdiuicD2e+zQkclxzJa5JEGLtV8XIOFVvisnGuw4l4xd6dfQozedwqR8JTeXQmxLebvYhlbwHoQP9RWkw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/remark-mdx-remove-esm/-/remark-mdx-remove-esm-1.3.2.tgz",
+      "integrity": "sha512-BvL8VSdVXy9S7NlHP56nUJAHFc45h5E9HnHiLUGHe5tw3Yvm/3cVZvAzlkEEh2i+fkq2uKrf2xn5VmItBhMypA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.4",
-        "mdast-util-mdxjs-esm": "^2.0.1",
         "unist-util-remove": "^4.0.0"
       },
       "peerDependencies": {


### PR DESCRIPTION
## Summary
- Bumps `next`, `@next/swc-wasm-nodejs`, `autoprefixer`, `next-mdx-remote-client`, `postcss`, `react`, and `react-dom` to their latest patch/minor versions — all already permitted by existing `package.json` caret ranges, so `package.json` itself is unchanged.
- Tailwind v4 and Prettier v3 are deliberately **excluded** — both are major, breaking upgrades (Tailwind's config format changes entirely; Prettier would reformat much of the codebase) and belong in their own follow-up work.
- Replaces the 30 stale Dependabot PRs (#38–#80), closed separately with an explanatory comment on each. Those PRs targeted Gatsby-era dependencies (gatsby, express, moment, socket.io, ajv, etc.) that no longer exist in this repo since the migration to Next.js in #86 — their lockfile diffs were also in the old npm lockfile v1 format, incompatible with the current lockfile v3 structure, so none of them were mergeable as-is.

| Package | Before | After |
|---|---|---|
| next | 16.2.6 | 16.2.10 |
| @next/swc-wasm-nodejs | 16.2.6 | 16.2.10 |
| autoprefixer | 10.5.0 | 10.5.4 |
| next-mdx-remote-client | 2.1.10 | 2.1.11 |
| postcss | 8.5.14 | 8.5.20 |
| react | 19.2.6 | 19.2.7 |
| react-dom | 19.2.6 | 19.2.7 |

## Testing
- `npm run build` completes successfully (55 static pages generated, no errors).
- `npm outdated` confirms only `prettier` and `tailwindcss` remain outdated (expected — deliberately excluded).
- `npm audit` shows the same 3 pre-existing moderate advisories before and after (`js-yaml <3.15.0` via `gray-matter`, and a `postcss` advisory nested inside `next`'s own bundled copy — confirmed `next@16.2.10` still bundles the same `postcss@8.4.31`, so this bump does not clear it).
- Code review (`ce:review`, 6 always-on reviewers: correctness, testing, maintainability, project-standards, agent-native, learnings-researcher) returned zero findings — expected for a lockfile-only diff.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — this is a personal static blog with no runtime services, background jobs, or user-facing state to watch. If the deployed site fails to build or render after merge, Vercel's own build failure notification is the signal; no custom dashboard or log query applies here.

Plan: [docs/plans/2026-07-19-001-chore-dependency-cleanup-plan.md](docs/plans/2026-07-19-001-chore-dependency-cleanup-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)